### PR TITLE
Fixed example-ct dimension error

### DIFF
--- a/example-ct/comps.jsonnet
+++ b/example-ct/comps.jsonnet
@@ -5,9 +5,8 @@ function(accts)
     // and countries-regions to England & Wales.
     accts.library.line("income", "Income from main trade")
 	.in_year()
-	.segment("activity", "m")
 	.segment("detailed-analysis", "item1")
-	.segment("countries-regions", "england-and-wales"),
+	.segment("countries-regions", "UK"),
 
     // Define an entertainment computation
     accts.library.line("entertainment", "Entertainment")


### PR DESCRIPTION
Fixed example, removed :
  RuntimeError: Config value segment.activity.dimension not known

This was a dimension from the previous taxonomy
