### PR TITLE
makefiles for example ct/accts/vat enable location of the JSONNET library to be overriden

### DIFF
--- a/Makefile.example-accts
+++ b/Makefile.example-accts
@@ -1,14 +1,35 @@
+#
+# This makefile is for a single target and builds it everytime
+#
 
+#
+# use the following command
+# make -f Makefile.example-accts
+# or
+# make -f Makefile.example-accts  JSONNET_DATA=../ixbrl-reporter-jsonnet
+#
+# The first assumes your current directory is ixbrl-reporter-jsonnet.
+# The second assumes that
+# you are supplying the path to the directory ixbrl-reporter-jsonnet.
+#
+
+# directory name where the example is, also build output name
 TEMPLATE=example-accts
-INPUTS=$(wildcard ${TEMPLATE}/*)
 
-all: example-accts.xhtml
+#uncomment to default the JSONNET library to being at this path
+#JSONNET_DATA ?= ../ixbrl-reporter-jsonnet
+
+#default the JSONNET library to being at this path
+JSONNET_DATA ?= .
+
+all: ${TEMPLATE}.xhtml
 
 FORCE:
 
 %.xhtml: %.json FORCE
 	ixbrl-reporter $< report ixbrl > $@
 
-example-accts.json: ${INPUTS} FORCE
-	jsonnet ${TEMPLATE}/${TEMPLATE}.jsonnet -J . -o $@
+${TEMPLATE}.json: ${TEMPLATE}/${TEMPLATE}.jsonnet FORCE
+	jsonnet $< -J ${JSONNET_DATA} -o $@
+
 

--- a/Makefile.example-ct
+++ b/Makefile.example-ct
@@ -1,14 +1,35 @@
+#
+# This makefile is for a single target and builds it everytime
+#
 
+#
+# use the following command
+# make -f Makefile.example-ct
+# or
+# make -f Makefile.example-ct  JSONNET_DATA=../ixbrl-reporter-jsonnet
+#
+# The first assumes your current directory is ixbrl-reporter-jsonnet.
+# The second assumes that
+# you are supplying the path to the directory ixbrl-reporter-jsonnet.
+#
+
+# directory name where the example is, also build output name
 TEMPLATE=example-ct
-INPUTS=$(wildcard ${TEMPLATE}/*)
 
-all: example-ct.xhtml
+#uncomment to default the JSONNET library to being at this path
+#JSONNET_DATA ?= ../ixbrl-reporter-jsonnet
+
+#default the JSONNET library to being at this path
+JSONNET_DATA ?= .
+
+all: ${TEMPLATE}.xhtml
 
 FORCE:
 
 %.xhtml: %.json FORCE
 	ixbrl-reporter $< report ixbrl > $@
 
-example-ct.json: ${INPUTS} FORCE
-	jsonnet ${TEMPLATE}/${TEMPLATE}.jsonnet -J . -o $@
+${TEMPLATE}.json: ${TEMPLATE}/${TEMPLATE}.jsonnet FORCE
+	jsonnet $< -J ${JSONNET_DATA} -o $@
+
 

--- a/Makefile.example-vat
+++ b/Makefile.example-vat
@@ -1,12 +1,35 @@
+#
+# This makefile is for a single target and builds it everytime
+#
 
+#
+# use the following command
+# make -f Makefile.example-vat
+# or
+# make -f Makefile.example-vat  JSONNET_DATA=../ixbrl-reporter-jsonnet
+#
+# The first assumes your current directory is ixbrl-reporter-jsonnet.
+# The second assumes that
+# you are supplying the path to the directory ixbrl-reporter-jsonnet.
+#
+
+# directory name where the example is, also build output name
 TEMPLATE=example-vat
-INPUTS=$(wildcard ${TEMPLATE}/*)
 
-all: vat.xhtml
+#uncomment to default the JSONNET library to being at this path
+#JSONNET_DATA ?= ../ixbrl-reporter-jsonnet
 
-%.xhtml: %.json
+#default the JSONNET library to being at this path
+JSONNET_DATA ?= .
+
+all: ${TEMPLATE}.xhtml
+
+FORCE:
+
+%.xhtml: %.json FORCE
 	ixbrl-reporter $< report ixbrl > $@
 
-vat.json: ${INPUTS}
-	jsonnet ${TEMPLATE}/${TEMPLATE}.jsonnet -J . -o $@
+${TEMPLATE}.json: ${TEMPLATE}/${TEMPLATE}.jsonnet FORCE
+	jsonnet $< -J ${JSONNET_DATA} -o $@
+
 


### PR DESCRIPTION
## Motivation

For the **wiki** instructions I would like to be able to recommend
```
make   -f    Makefile.example-accts
```
for building in the GitHub tree
or
```
make   -f    Makefile.example-accts   JSONNET_DATA=../ixbrl-reporter
```
for building in a directory outside the GitHub controlled directory.
## Changes

I've also commented the makefiles for example ct/accts/vat to hopefully enable them to be used effectively.

all three are identical Except for the **TEMPLATE=** expression.
The active makefile code now looks like
```
TEMPLATE=example-accts
JSONNET_DATA ?= .
all: ${TEMPLATE}.xhtml
FORCE:
%.xhtml: %.json FORCE
	ixbrl-reporter $< report ixbrl > $@
${TEMPLATE}.json: ${TEMPLATE}/${TEMPLATE}.jsonnet FORCE
	jsonnet $< -J ${JSONNET_DATA} -o $@
```
## Tests
All tests pass
FAO: @cybermaggedon 