### PR TITLE
Add suppress_if_zero zero_if_less_than_zero zero_if_greater_than_zero

### DIFF
--- a/lib/base.libsonnet
+++ b/lib/base.libsonnet
@@ -217,6 +217,9 @@
 	    else
 	        self + { segments: [ { [k]: v } ] },
 	reverse_sign():: self + { "reverse-sign": true },
+	suppress_if_zero():: self + { "suppress-if-zero": true },
+	zero_if_less_than_zero():: self + { "zero-if": "less-than-zero" },
+	zero_if_greater_than_zero():: self + { "zero-if": "greater-than-zero" },
 
     },
 


### PR DESCRIPTION
- Added a computation setting `suppress_if_zero` which if applied to a line, AND  all periods have a zero, value, then removes the line from the report. This will also mean iXBRL tags will not be emitted for the value at that point in the report (it could end up being reported and tagged elsewhere).
- Added a setting `zero_if_less_than_zero` which, if set AND the value is less than zero, treats the value as if it were zero.  In the report, zero may be shown.  If tagged, the tags will show zero. Further, if suppress-zero is set, the value may not be shown at all (and no tag output).
- A `zero_if_greater_than_zero` which is the reverse condition on the less-than-zero case.
